### PR TITLE
Add token range service module and API request example

### DIFF
--- a/Api/src/UrlShortener.Api/Api.http
+++ b/Api/src/UrlShortener.Api/Api.http
@@ -1,0 +1,11 @@
+﻿@Api_HostAddress = https://api-67vqx2skfuk4m.azurewebsites.net/
+
+POST {{Api_HostAddress}}/api/urls
+Accept: application/json
+Content-Type: application/json
+
+{
+  "LongUrl": "https://notion.com"
+}
+
+###

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -1,4 +1,6 @@
-﻿param location string = resourceGroup().location
+﻿// az deployment group what-if --resource-group urlshortener-dev --template-file infrastructure/main.bicep
+
+param location string = resourceGroup().location
 var uniqueId = uniqueString(resourceGroup().id)
 
 module keyVault 'modules/secrets/keyvalut.bicep' = {
@@ -30,6 +32,16 @@ module apiService 'modules/compute/appservice.bicep' = {
   //     dependsOn: [
   //         keyVault
   //     ]
+}
+
+module tokenRangeService 'modules/compute/appservice.bicep' = {
+  name: 'tokenRangeServiceDevelopment'
+  params: {
+    appName: 'token-range-service-${uniqueId}'
+    appServicePlanName: 'plan-token-range-${uniqueId}'
+    location: location
+    keyVaultName: keyVault.outputs.name
+  }
 }
 
 module cosmosDb 'modules/storage/cosmos-db.bicep' = {


### PR DESCRIPTION
Added a new `tokenRangeService` module to the Bicep file for deployment of the Token Range Service with necessary parameters. Also introduced an `Api.http` file with an example API request for URL shortening to simplify testing and integrations.